### PR TITLE
Upgrade Spring Boot version to 2.6.6 due to RCE vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.3</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/src/main/java/org/czertainly/cryptosense/certificate/discovery/EndpointsListener.java
+++ b/src/main/java/org/czertainly/cryptosense/certificate/discovery/EndpointsListener.java
@@ -28,12 +28,12 @@ public class EndpointsListener {
                 .filter(e -> (e.getKey().getMethodsCondition().getMethods() != null && !e.getKey().getMethodsCondition().getMethods().isEmpty()))
                 .forEach(e -> {
                     LOGGER.info("{} {} {}", e.getKey().getMethodsCondition().getMethods(),
-                            e.getKey().getPatternsCondition().getPatterns(),
+                            e.getKey().getPatternValues(),
                             e.getValue().getMethod().getName());
 
                     EndpointDto endpoint = new EndpointDto();
                     endpoint.setMethod(e.getKey().getMethodsCondition().getMethods().iterator().next().name());
-                    endpoint.setContext(e.getKey().getPatternsCondition().getPatterns().iterator().next());
+                    endpoint.setContext(e.getKey().getPatternValues().iterator().next());
                     endpoint.setName(e.getValue().getMethod().getName());
                     endpoints.add(endpoint);
                 });


### PR DESCRIPTION
**Issue:** New Vulnerabilities have been discovered in the Springboot version <2.6.

**Fix:** Upgraded Springboot version to 2.6.6 as recommended.

**Impact:** The endpoint listener uses a method to get the list of available patterns. There are changes to the method implemented.

closes #17 