### PR TITLE
Update Credential Attribute Content with New Content Data Type

### DIFF
--- a/src/main/java/com/czertainly/cryptosense/certificate/discovery/dto/AnalyzerRequestDto.java
+++ b/src/main/java/com/czertainly/cryptosense/certificate/discovery/dto/AnalyzerRequestDto.java
@@ -1,5 +1,6 @@
 package com.czertainly.cryptosense.certificate.discovery.dto;
 
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,5 +14,5 @@ import lombok.Setter;
 public class AnalyzerRequestDto {
 
     private String apiUrl;
-    private CredentialDto credentialKind;
+    private CredentialAttributeContentData credentialKind;
 }

--- a/src/main/java/com/czertainly/cryptosense/certificate/discovery/service/impl/DiscoveryServiceImpl.java
+++ b/src/main/java/com/czertainly/cryptosense/certificate/discovery/service/impl/DiscoveryServiceImpl.java
@@ -6,6 +6,7 @@ import com.czertainly.api.model.common.attribute.v2.MetadataAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
 import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContent;
 import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.common.attribute.v2.properties.MetadataAttributeProperties;
 import com.czertainly.api.model.connector.discovery.DiscoveryDataRequestDto;
 import com.czertainly.api.model.connector.discovery.DiscoveryProviderDto;
@@ -109,7 +110,7 @@ public class DiscoveryServiceImpl implements DiscoveryService {
     private void discoverCertificateInternal(DiscoveryRequestDto request, DiscoveryHistory history) throws NullPointerException {
         logger.info("Discovery initiated for the request with name {}", request.getName());
         String apiUrl = AttributeDefinitionUtils.getSingleItemAttributeContentValue(AttributeServiceImpl.ATTRIBUTE_API_URL, request.getAttributes(), StringAttributeContent.class).getData();
-        CredentialDto apiKeyCredential = AttributeDefinitionUtils.getCredentialContent("apiKey", request.getAttributes());
+        CredentialAttributeContentData apiKeyCredential = AttributeDefinitionUtils.getCredentialContent("apiKey", request.getAttributes());
         final AnalyzerProject selectedProject = AttributeDefinitionUtils.getObjectAttributeContentData(AttributeServiceImpl.ATTRIBUTE_PROJECT, request.getAttributes(), AnalyzerProject.class).get(0);
         final AnalyzerReport selectedReport = AttributeDefinitionUtils.getObjectAttributeContentData(AttributeServiceImpl.ATTRIBUTE_REPORT, request.getAttributes(), AnalyzerReport.class).get(0);
         AnalyzerRequestDto analyzerRequestDto = new AnalyzerRequestDto();

--- a/src/test/java/com/czertainly/cryptosense/certificate/discovery/service/AnalyzerTest.java
+++ b/src/test/java/com/czertainly/cryptosense/certificate/discovery/service/AnalyzerTest.java
@@ -1,7 +1,9 @@
 package com.czertainly.cryptosense.certificate.discovery.service;
 
 import com.czertainly.api.model.client.attribute.ResponseAttributeDto;
+import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.czertainly.cryptosense.certificate.discovery.dto.AnalyzerRequestDto;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -27,7 +29,7 @@ public class AnalyzerTest {
 
     private WireMockServer mockServer;
 
-    private CredentialDto credDto;
+    private CredentialAttributeContentData credDto;
 
     @BeforeEach
     public void setUp() {
@@ -36,13 +38,11 @@ public class AnalyzerTest {
 
         WireMock.configureFor("localhost", mockServer.port());
 
-        credDto = new CredentialDto();
+        credDto = new CredentialAttributeContentData();
         credDto.setUuid("57fd083e-92c5-411c-964c-5b4e7fe35205");
         credDto.setName("test");
-        credDto.setEnabled(true);
-        credDto.setConnectorName("Test Connector");
 
-        ResponseAttributeDto apiKey = new ResponseAttributeDto();
+        DataAttribute apiKey = new DataAttribute();
         apiKey.setUuid("aac5c2d5-5dc3-4ddb-9dfa-3d76b99135f8");
         apiKey.setName("apiKey");
         apiKey.setContent(List.of(new StringAttributeContent("asdfEDssdfhcHJSHxhFxf")));


### PR DESCRIPTION
For the credential Attribute type, create a new data type for the content as the credential to contains ResponseAttributeDto and will not propagate the secrets to the connector

links 3KeyCompany/CZERTAINLY-Interfaces#133